### PR TITLE
Add workflow pipeline and comprehensive testing infrastructure

### DIFF
--- a/src/julee/contrib/polling/apps/__init__.py
+++ b/src/julee/contrib/polling/apps/__init__.py
@@ -1,0 +1,17 @@
+"""
+Application entry points for the polling contrib module.
+
+This module contains the application-layer components that provide entry points
+for the polling contrib module, including worker pipelines, API routes, and
+CLI commands.
+
+Following the ADR contrib module structure, this layer wires together domain
+services and infrastructure implementations into runnable applications.
+
+No re-exports to avoid import chains that pull non-deterministic code
+into Temporal workflows. Import directly from specific modules:
+
+- from julee.contrib.polling.apps.worker.pipelines import NewDataDetectionPipeline
+"""
+
+__all__ = []

--- a/src/julee/contrib/polling/apps/worker/__init__.py
+++ b/src/julee/contrib/polling/apps/worker/__init__.py
@@ -1,0 +1,17 @@
+"""
+Worker applications for the polling contrib module.
+
+This module contains worker-specific entry points for the polling contrib module,
+including Temporal workflows (pipelines) that orchestrate polling operations
+with durability guarantees.
+
+The worker applications in this module can be registered with Temporal workers
+to provide polling capabilities within workflow contexts.
+
+No re-exports to avoid import chains that pull non-deterministic code
+into Temporal workflows. Import directly from specific modules:
+
+- from julee.contrib.polling.apps.worker.pipelines import NewDataDetectionPipeline
+"""
+
+__all__ = []

--- a/src/julee/contrib/polling/apps/worker/pipelines.py
+++ b/src/julee/contrib/polling/apps/worker/pipelines.py
@@ -1,0 +1,285 @@
+"""
+Temporal workflows for polling operations in the Julee polling contrib module.
+
+This module contains workflows that orchestrate polling operations with
+Temporal's durability guarantees, providing retry logic, state management,
+and reliable execution for endpoint polling and change detection.
+"""
+
+import hashlib
+import logging
+from typing import Any
+
+from temporalio import workflow
+
+from julee.contrib.polling.domain.models.polling_config import PollingConfig
+from julee.contrib.polling.infrastructure.temporal.proxies import (
+    WorkflowPollerServiceProxy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@workflow.defn
+class NewDataDetectionPipeline:
+    """
+    Temporal workflow for endpoint polling with new data detection.
+
+    This workflow:
+    1. Polls an endpoint using the configured polling service
+    2. Compares result with previous completion to detect changes
+    3. Triggers downstream processing when new data is detected
+    4. Returns completion result for next scheduled execution
+
+    The workflow uses Temporal's schedule last completion result feature
+    to automatically receive the previous execution's result for comparison.
+    """
+
+    def __init__(self) -> None:
+        self.current_step = "initialized"
+        self.endpoint_id: str | None = None
+        self.has_new_data: bool = False
+
+    @workflow.query
+    def get_current_step(self) -> str:
+        """Query method to get the current workflow step."""
+        return self.current_step
+
+    @workflow.query
+    def get_endpoint_id(self) -> str | None:
+        """Query method to get the endpoint ID being polled."""
+        return self.endpoint_id
+
+    @workflow.query
+    def get_has_new_data(self) -> bool:
+        """Query method to check if new data was detected."""
+        return self.has_new_data
+
+    async def trigger_downstream_pipeline(
+        self,
+        downstream_pipeline: str,
+        previous_data: bytes | None,
+        new_data: bytes,
+    ) -> bool:
+        """
+        Trigger downstream pipeline workflow.
+
+        Args:
+            downstream_pipeline: Name of the downstream workflow to trigger
+            previous_data: Previous content (None if first run)
+            new_data: New content that was detected
+
+        Returns:
+            True if successfully triggered, False otherwise
+        """
+        try:
+            # Start external workflow for downstream processing (fire-and-forget)
+            await workflow.start_child_workflow(
+                downstream_pipeline,  # This would be the workflow class name
+                args=[previous_data, new_data],
+                id=f"downstream-{self.endpoint_id}-{workflow.info().workflow_id}",
+                task_queue="downstream-processing-queue",
+            )
+
+            workflow.logger.info(
+                "Downstream pipeline triggered successfully",
+                extra={
+                    "endpoint_id": self.endpoint_id,
+                    "downstream_pipeline": downstream_pipeline,
+                },
+            )
+            return True
+
+        except Exception as e:
+            workflow.logger.error(
+                "Failed to trigger downstream pipeline",
+                extra={
+                    "endpoint_id": self.endpoint_id,
+                    "downstream_pipeline": downstream_pipeline,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+            )
+            # Don't fail the polling workflow if downstream trigger fails
+            return False
+
+    @workflow.run
+    async def run(
+        self,
+        config: PollingConfig,
+        downstream_pipeline: str | None = None,
+        previous_completion: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Execute the new data detection workflow.
+
+        Args:
+            config: Configuration for the polling operation
+            downstream_pipeline: Optional pipeline to trigger when new data detected
+            previous_completion: Previous workflow completion result (from Temporal schedule)
+
+        Returns:
+            Completion result containing polling result and detection metadata
+
+        Raises:
+            RuntimeError: If polling or downstream processing fails after retries
+        """
+        self.endpoint_id = config.endpoint_identifier
+
+        workflow.logger.info(
+            "Starting new data detection pipeline",
+            extra={
+                "endpoint_id": self.endpoint_id,
+                "polling_protocol": config.polling_protocol.value,
+                "has_previous_completion": previous_completion is not None,
+                "workflow_id": workflow.info().workflow_id,
+                "run_id": workflow.info().run_id,
+            },
+        )
+
+        self.current_step = "polling_endpoint"
+
+        try:
+            # Step 1: Poll the endpoint
+            polling_service = WorkflowPollerServiceProxy()
+            polling_result = await polling_service.poll_endpoint(config)
+
+            # Extract the timestamp from when polling actually happened
+            polled_at = polling_result.polled_at.isoformat()
+
+            workflow.logger.debug(
+                "Polling completed",
+                extra={
+                    "endpoint_id": self.endpoint_id,
+                    "polling_success": polling_result.success,
+                    "content_length": len(polling_result.content),
+                },
+            )
+
+            self.current_step = "detecting_changes"
+
+            # Step 2: Detect new data using hash comparison
+            current_content = polling_result.content
+            current_hash = hashlib.sha256(current_content).hexdigest()
+
+            previous_hash = None
+            if previous_completion and "polling_result" in previous_completion:
+                previous_hash = previous_completion["polling_result"].get(
+                    "content_hash"
+                )
+
+            has_new_data = previous_hash != current_hash
+            self.has_new_data = has_new_data
+
+            workflow.logger.info(
+                "Change detection completed",
+                extra={
+                    "endpoint_id": self.endpoint_id,
+                    "has_new_data": has_new_data,
+                    "is_first_run": previous_hash is None,
+                    "content_hash": current_hash,
+                },
+            )
+
+            # Step 3: Trigger downstream processing if new data detected
+            downstream_triggered = False
+            if has_new_data and downstream_pipeline:
+                self.current_step = "triggering_downstream"
+
+                workflow.logger.info(
+                    "Triggering downstream pipeline",
+                    extra={
+                        "endpoint_id": self.endpoint_id,
+                        "downstream_pipeline": downstream_pipeline,
+                        "content_length": len(current_content),
+                    },
+                )
+
+                # Get previous data for comparison
+                previous_data = None
+                if previous_completion and "polling_result" in previous_completion:
+                    prev_content_str = previous_completion["polling_result"].get(
+                        "content"
+                    )
+                    if prev_content_str:
+                        try:
+                            previous_data = prev_content_str.encode("utf-8")
+                        except (UnicodeDecodeError, AttributeError) as e:
+                            workflow.logger.error(
+                                "Failed to decode previous content for downstream pipeline",
+                                extra={
+                                    "endpoint_id": self.endpoint_id,
+                                    "error": str(e),
+                                    "error_type": type(e).__name__,
+                                },
+                            )
+                            raise RuntimeError(
+                                f"Previous content is corrupted or invalid: {e}"
+                            )
+                    elif previous_hash:
+                        # We have previous run but no content - this is an error
+                        workflow.logger.error(
+                            "Previous content not available for downstream pipeline but previous hash exists",
+                            extra={
+                                "endpoint_id": self.endpoint_id,
+                                "previous_hash": previous_hash,
+                            },
+                        )
+                        raise RuntimeError(
+                            "Previous content is missing from completion result but is required for downstream pipeline"
+                        )
+
+                downstream_triggered = await self.trigger_downstream_pipeline(
+                    downstream_pipeline,
+                    previous_data,
+                    current_content,
+                )
+
+            self.current_step = "completed"
+
+            # Step 4: Return completion result for next scheduled execution
+            completion_result = {
+                "polling_result": {
+                    "success": polling_result.success,
+                    "content_hash": current_hash,
+                    "content": current_content.decode("utf-8", errors="ignore"),
+                    "polled_at": polled_at,
+                    "content_length": len(current_content),
+                },
+                "detection_result": {
+                    "has_new_data": has_new_data,
+                    "previous_hash": previous_hash,
+                    "current_hash": current_hash,
+                },
+                "downstream_triggered": downstream_triggered,
+                "endpoint_id": self.endpoint_id,
+                "completed_at": workflow.now().isoformat(),
+            }
+
+            workflow.logger.info(
+                "New data detection pipeline completed successfully",
+                extra={
+                    "endpoint_id": self.endpoint_id,
+                    "has_new_data": has_new_data,
+                    "downstream_triggered": downstream_triggered,
+                },
+            )
+
+            return completion_result
+
+        except Exception as e:
+            self.current_step = "failed"
+
+            workflow.logger.error(
+                "New data detection pipeline failed",
+                extra={
+                    "endpoint_id": self.endpoint_id,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "current_step": self.current_step,
+                },
+                exc_info=True,
+            )
+
+            # Re-raise to let Temporal handle retry logic
+            raise

--- a/src/julee/contrib/polling/tests/unit/apps/worker/test_pipelines.py
+++ b/src/julee/contrib/polling/tests/unit/apps/worker/test_pipelines.py
@@ -1,0 +1,555 @@
+"""
+Unit tests for polling worker pipelines.
+
+This module tests the NewDataDetectionPipeline workflow using Temporal's test
+environment, which provides realistic workflow execution with time-skipping
+capabilities while maintaining fast test performance.
+
+The tests mock external dependencies (activities) while testing the actual
+workflow orchestration logic and temporal behaviors.
+"""
+
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio import activity
+from temporalio.client import WorkflowFailureError
+from temporalio.contrib.pydantic import pydantic_data_converter
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from julee.contrib.polling.apps.worker.pipelines import NewDataDetectionPipeline
+from julee.contrib.polling.domain.models.polling_config import (
+    PollingConfig,
+    PollingProtocol,
+    PollingResult,
+)
+
+
+@pytest.fixture
+async def workflow_env():
+    """Provide a Temporal test environment with time skipping."""
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=pydantic_data_converter
+    ) as env:
+        yield env
+
+
+@pytest.fixture
+def sample_config():
+    """Provide a sample PollingConfig for testing."""
+    return PollingConfig(
+        endpoint_identifier="test-api",
+        polling_protocol=PollingProtocol.HTTP,
+        connection_params={"url": "https://api.example.com/data"},
+        timeout_seconds=30,
+    )
+
+
+@pytest.fixture
+def mock_polling_results():
+    """Provide sample polling results for different scenarios."""
+    return {
+        "first_data": PollingResult(
+            success=True,
+            content=b"first response data",
+            polled_at=datetime.now(timezone.utc),
+            content_hash=hashlib.sha256(b"first response data").hexdigest(),
+        ),
+        "changed_data": PollingResult(
+            success=True,
+            content=b"changed response data",
+            polled_at=datetime.now(timezone.utc),
+            content_hash=hashlib.sha256(b"changed response data").hexdigest(),
+        ),
+        "same_data": PollingResult(
+            success=True,
+            content=b"first response data",  # Same as first_data
+            polled_at=datetime.now(timezone.utc),
+            content_hash=hashlib.sha256(b"first response data").hexdigest(),
+        ),
+        "failed_polling": PollingResult(
+            success=False,
+            content=b"",
+            polled_at=datetime.now(timezone.utc),
+            error_message="Connection timeout",
+        ),
+    }
+
+
+# Mock activity for polling operations - will be patched in tests
+@activity.defn(name="julee.contrib.polling.poll_endpoint")
+async def mock_poll_endpoint(config: PollingConfig) -> PollingResult:
+    """Mock polling activity - should be patched in tests."""
+    return PollingResult(
+        success=True,
+        content=b"default mock response",
+        polled_at=datetime.now(timezone.utc),
+    )
+
+
+class TestNewDataDetectionPipelineFirstRun:
+    """Test first run scenarios (no previous completion)."""
+
+    @pytest.mark.asyncio
+    async def test_first_run_detects_new_data(
+        self, workflow_env, sample_config, mock_polling_results
+    ):
+        """Test first run always detects new data."""
+
+        # Create a mock activity function that returns the desired response
+        @activity.defn(name="julee.contrib.polling.poll_endpoint")
+        async def test_mock_activity(config: PollingConfig) -> PollingResult:
+            content_str = "first response data"
+            return PollingResult(
+                success=True,
+                content=content_str.encode(),
+                polled_at=datetime.now(timezone.utc),
+                content_hash=hashlib.sha256(content_str.encode()).hexdigest(),
+            )
+
+        async with Worker(
+            workflow_env.client,
+            task_queue="test-queue",
+            workflows=[NewDataDetectionPipeline],
+            activities=[test_mock_activity],
+        ):
+            # Execute workflow with no previous completion
+            result = await workflow_env.client.execute_workflow(
+                NewDataDetectionPipeline.run,
+                args=[
+                    sample_config,
+                    None,
+                    None,
+                ],  # config, downstream_pipeline, previous_completion
+                id=str(uuid.uuid4()),
+                task_queue="test-queue",
+            )
+
+            # Verify first run behavior
+            assert result["detection_result"]["has_new_data"] is True
+            assert result["detection_result"]["previous_hash"] is None
+            assert result["downstream_triggered"] is False
+            assert result["endpoint_id"] == "test-api"
+
+            # Verify polling result structure
+            polling_result = result["polling_result"]
+            assert polling_result["success"] is True
+            assert (
+                polling_result["content_hash"]
+                == hashlib.sha256(b"first response data").hexdigest()
+            )
+            assert "polled_at" in polling_result
+            assert "content_length" in polling_result
+
+    @pytest.mark.asyncio
+    async def test_first_run_with_downstream_pipeline(
+        self, workflow_env, sample_config, mock_polling_results
+    ):
+        """Test first run with downstream pipeline triggering."""
+
+        # Create a mock activity function that returns the desired response
+        @activity.defn(name="julee.contrib.polling.poll_endpoint")
+        async def test_mock_activity(config: PollingConfig) -> PollingResult:
+            content_bytes = b"first response data"
+            return PollingResult(
+                success=True,
+                content=content_bytes,
+                polled_at=datetime.now(timezone.utc),
+                content_hash=hashlib.sha256(content_bytes).hexdigest(),
+            )
+
+        # Mock workflow.start_workflow to avoid trying to start actual downstream workflows
+        with patch(
+            "julee.contrib.polling.apps.worker.pipelines.workflow.start_child_workflow",
+            new_callable=AsyncMock,
+        ) as mock_start:
+            async with Worker(
+                workflow_env.client,
+                task_queue="test-queue",
+                workflows=[NewDataDetectionPipeline],
+                activities=[test_mock_activity],
+            ):
+                result = await workflow_env.client.execute_workflow(
+                    NewDataDetectionPipeline.run,
+                    args=[
+                        sample_config,
+                        "TestDownstreamWorkflow",
+                        None,
+                    ],  # config, downstream_pipeline, previous_completion
+                    id=str(uuid.uuid4()),
+                    task_queue="test-queue",
+                )
+
+                # Verify downstream was triggered
+                assert result["downstream_triggered"] is True
+                mock_start.assert_called_once()
+
+                # Verify downstream workflow call parameters
+                call_args = mock_start.call_args
+                # For start_child_workflow, the workflow name is the first positional arg
+                assert call_args[0][0] == "TestDownstreamWorkflow"  # Workflow name
+                # The args parameter is passed as a keyword argument
+                assert call_args[1]["args"] == [
+                    None,
+                    b"first response data",
+                ]  # Args: previous_data, new_data
+                assert (
+                    "downstream-test-api-" in call_args[1]["id"]
+                )  # Workflow ID contains endpoint
+                assert call_args[1]["task_queue"] == "downstream-processing-queue"
+
+
+class TestNewDataDetectionPipelineSubsequentRuns:
+    """Test subsequent runs with previous completion data."""
+
+    @pytest.mark.asyncio
+    async def test_no_changes_detected(
+        self, workflow_env, sample_config, mock_polling_results
+    ):
+        """Test when content hasn't changed since last run."""
+
+        # Create a mock activity function that returns the desired response
+        @activity.defn(name="julee.contrib.polling.poll_endpoint")
+        async def test_mock_activity(config: PollingConfig) -> PollingResult:
+            content_bytes = b"first response data"  # Same as first_data
+            return PollingResult(
+                success=True,
+                content=content_bytes,
+                polled_at=datetime.now(timezone.utc),
+                content_hash=hashlib.sha256(content_bytes).hexdigest(),
+            )
+
+        # Create previous completion with same hash
+        previous_completion = {
+            "polling_result": {
+                "content_hash": hashlib.sha256(b"first response data").hexdigest(),
+                "content": "first response data",
+                "success": True,
+            },
+            "endpoint_id": "test-api",
+        }
+
+        async with Worker(
+            workflow_env.client,
+            task_queue="test-queue",
+            workflows=[NewDataDetectionPipeline],
+            activities=[test_mock_activity],
+        ):
+            result = await workflow_env.client.execute_workflow(
+                NewDataDetectionPipeline.run,
+                args=[
+                    sample_config,
+                    None,
+                    previous_completion,
+                ],  # config, downstream_pipeline, previous_completion
+                id=str(uuid.uuid4()),
+                task_queue="test-queue",
+            )
+
+            # Verify no changes detected
+            assert result["detection_result"]["has_new_data"] is False
+            assert result["downstream_triggered"] is False
+            assert result["detection_result"]["previous_hash"] is not None
+
+    @pytest.mark.asyncio
+    async def test_changes_detected(
+        self, workflow_env, sample_config, mock_polling_results
+    ):
+        """Test when content has changed since last run."""
+
+        # Create a mock activity function that returns the desired response
+        @activity.defn(name="julee.contrib.polling.poll_endpoint")
+        async def test_mock_activity(config: PollingConfig) -> PollingResult:
+            content_bytes = b"changed response data"
+            return PollingResult(
+                success=True,
+                content=content_bytes,
+                polled_at=datetime.now(timezone.utc),
+                content_hash=hashlib.sha256(content_bytes).hexdigest(),
+            )
+
+        # Create previous completion with different hash
+        previous_completion = {
+            "polling_result": {
+                "content_hash": hashlib.sha256(b"first response data").hexdigest(),
+                "content": "first response data",
+                "success": True,
+            },
+            "endpoint_id": "test-api",
+        }
+
+        with patch(
+            "julee.contrib.polling.apps.worker.pipelines.workflow.start_child_workflow",
+            new_callable=AsyncMock,
+        ) as mock_start:
+            async with Worker(
+                workflow_env.client,
+                task_queue="test-queue",
+                workflows=[NewDataDetectionPipeline],
+                activities=[test_mock_activity],
+            ):
+                result = await workflow_env.client.execute_workflow(
+                    NewDataDetectionPipeline.run,
+                    args=[
+                        sample_config,
+                        "TestDownstreamWorkflow",
+                        previous_completion,
+                    ],  # config, downstream_pipeline, previous_completion
+                    id=str(uuid.uuid4()),
+                    task_queue="test-queue",
+                )
+
+                # Verify changes detected and downstream triggered
+                assert result["detection_result"]["has_new_data"] is True
+                assert result["downstream_triggered"] is True
+                assert (
+                    result["detection_result"]["current_hash"]
+                    != result["detection_result"]["previous_hash"]
+                )
+                mock_start.assert_called_once()
+
+
+class TestNewDataDetectionPipelineWorkflowQueries:
+    """Test workflow query methods during execution."""
+
+    @pytest.mark.asyncio
+    async def test_workflow_queries(
+        self, workflow_env, sample_config, mock_polling_results
+    ):
+        """Test that workflow queries return correct state information."""
+
+        # Create a slow mock activity to allow time for queries
+        @activity.defn(name="julee.contrib.polling.poll_endpoint")
+        async def test_mock_activity(config: PollingConfig) -> PollingResult:
+            await workflow_env.sleep(1)  # Add delay to allow queries
+            content_bytes = b"first response data"
+            return PollingResult(
+                success=True,
+                content=content_bytes,
+                polled_at=datetime.now(timezone.utc),
+                content_hash=hashlib.sha256(content_bytes).hexdigest(),
+            )
+
+        async with Worker(
+            workflow_env.client,
+            task_queue="test-queue",
+            workflows=[NewDataDetectionPipeline],
+            activities=[test_mock_activity],
+        ):
+            # Start workflow
+            handle = await workflow_env.client.start_workflow(
+                NewDataDetectionPipeline.run,
+                args=[
+                    sample_config,
+                    None,
+                    None,
+                ],  # config, downstream_pipeline, previous_completion
+                id=str(uuid.uuid4()),
+                task_queue="test-queue",
+            )
+
+            # Query initial state
+            current_step = await handle.query(NewDataDetectionPipeline.get_current_step)
+            endpoint_id = await handle.query(NewDataDetectionPipeline.get_endpoint_id)
+            has_new_data = await handle.query(NewDataDetectionPipeline.get_has_new_data)
+
+            # Verify initial query responses
+            assert current_step in [
+                "initialized",
+                "polling_endpoint",
+                "detecting_changes",
+                "completed",
+            ]
+            assert endpoint_id == "test-api"
+            assert isinstance(has_new_data, bool)
+
+            # Wait for completion
+            await handle.result()
+
+            # Query final state
+            final_step = await handle.query(NewDataDetectionPipeline.get_current_step)
+            final_has_new_data = await handle.query(
+                NewDataDetectionPipeline.get_has_new_data
+            )
+
+            assert final_step == "completed"
+            assert final_has_new_data is True  # First run should detect new data
+
+
+class TestNewDataDetectionPipelineErrorHandling:
+    """Test error handling and failure scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_polling_activity_failure(
+        self, workflow_env, sample_config, mock_polling_results
+    ):
+        """Test workflow behavior when polling activity fails."""
+
+        # Create a failing mock activity
+        @activity.defn(name="julee.contrib.polling.poll_endpoint")
+        async def test_mock_activity(config: PollingConfig) -> PollingResult:
+            raise RuntimeError("Polling failed")
+
+        async with Worker(
+            workflow_env.client,
+            task_queue="test-queue",
+            workflows=[NewDataDetectionPipeline],
+            activities=[test_mock_activity],
+        ):
+            # Workflow should fail and re-raise the exception
+            with pytest.raises(WorkflowFailureError):
+                await workflow_env.client.execute_workflow(
+                    NewDataDetectionPipeline.run,
+                    args=[
+                        sample_config,
+                        None,
+                        None,
+                    ],  # config, downstream_pipeline, previous_completion
+                    id=str(uuid.uuid4()),
+                    task_queue="test-queue",
+                )
+
+    @pytest.mark.asyncio
+    async def test_downstream_trigger_failure_doesnt_fail_workflow(
+        self, workflow_env, sample_config, mock_polling_results
+    ):
+        """Test that downstream pipeline failures don't fail the main workflow."""
+
+        # Create a mock activity function that returns the desired response
+        @activity.defn(name="julee.contrib.polling.poll_endpoint")
+        async def test_mock_activity(config: PollingConfig) -> PollingResult:
+            content_bytes = b"first response data"
+            return PollingResult(
+                success=True,
+                content=content_bytes,
+                polled_at=datetime.now(timezone.utc),
+                content_hash=hashlib.sha256(content_bytes).hexdigest(),
+            )
+
+        # Mock workflow.start_workflow to raise an exception
+        with patch(
+            "julee.contrib.polling.apps.worker.pipelines.workflow.start_child_workflow",
+            side_effect=RuntimeError("Downstream failed"),
+        ):
+            async with Worker(
+                workflow_env.client,
+                task_queue="test-queue",
+                workflows=[NewDataDetectionPipeline],
+                activities=[test_mock_activity],
+            ):
+                # Workflow should complete successfully despite downstream failure
+                result = await workflow_env.client.execute_workflow(
+                    NewDataDetectionPipeline.run,
+                    args=[
+                        sample_config,
+                        "TestDownstreamWorkflow",
+                        None,
+                    ],  # config, downstream_pipeline, previous_completion
+                    id=str(uuid.uuid4()),
+                    task_queue="test-queue",
+                )
+
+                # Verify workflow completed but downstream triggering failed
+                assert result["detection_result"]["has_new_data"] is True
+                assert (
+                    result["downstream_triggered"] is False
+                )  # Should be False due to failure
+
+
+class TestNewDataDetectionPipelineIntegration:
+    """Integration tests for complete workflow scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_complete_polling_cycle(
+        self, workflow_env, sample_config, mock_polling_results
+    ):
+        """Test a complete polling cycle: first run -> no changes -> changes detected."""
+        responses = [
+            mock_polling_results["first_data"],
+            mock_polling_results["same_data"],
+            mock_polling_results["changed_data"],
+        ]
+        response_index = 0
+
+        # Create a cycling mock activity that returns different responses
+        @activity.defn(name="julee.contrib.polling.poll_endpoint")
+        async def test_mock_activity(config: PollingConfig) -> PollingResult:
+            nonlocal response_index
+            if response_index == 0:
+                content_bytes = b"first response data"
+            elif response_index == 1:
+                content_bytes = b"first response data"  # Same as first
+            else:
+                content_bytes = b"changed response data"
+
+            result = PollingResult(
+                success=True,
+                content=content_bytes,
+                polled_at=datetime.now(timezone.utc),
+                content_hash=hashlib.sha256(content_bytes).hexdigest(),
+            )
+            response_index = min(response_index + 1, len(responses) - 1)
+            return result
+
+        with patch(
+            "julee.contrib.polling.apps.worker.pipelines.workflow.start_child_workflow",
+            new_callable=AsyncMock,
+        ) as mock_start:
+            async with Worker(
+                workflow_env.client,
+                task_queue="test-queue",
+                workflows=[NewDataDetectionPipeline],
+                activities=[test_mock_activity],
+            ):
+                # Workflow should complete successfully despite downstream failure
+                # First run - should detect new data
+                result1 = await workflow_env.client.execute_workflow(
+                    NewDataDetectionPipeline.run,
+                    args=[
+                        sample_config,
+                        "TestDownstreamWorkflow",
+                        None,
+                    ],  # config, downstream_pipeline, previous_completion
+                    id=str(uuid.uuid4()),
+                    task_queue="test-queue",
+                )
+
+                assert result1["detection_result"]["has_new_data"] is True
+                assert result1["downstream_triggered"] is True
+
+                # Second run - same content, no changes
+                result2 = await workflow_env.client.execute_workflow(
+                    NewDataDetectionPipeline.run,
+                    args=[
+                        sample_config,
+                        "TestDownstreamWorkflow",
+                        result1,
+                    ],  # config, downstream_pipeline, previous_completion
+                    id=str(uuid.uuid4()),
+                    task_queue="test-queue",
+                )
+
+                assert result2["detection_result"]["has_new_data"] is False
+                assert result2["downstream_triggered"] is False
+
+                # Third run - changed content, should detect changes
+                result3 = await workflow_env.client.execute_workflow(
+                    NewDataDetectionPipeline.run,
+                    args=[
+                        sample_config,
+                        "TestDownstreamWorkflow",
+                        result2,
+                    ],  # config, downstream_pipeline, previous_completion
+                    id=str(uuid.uuid4()),
+                    task_queue="test-queue",
+                )
+
+                assert result3["detection_result"]["has_new_data"] is True
+                assert result3["downstream_triggered"] is True
+
+                # Verify downstream was called twice (run 1 and run 3)
+                assert mock_start.call_count == 2


### PR DESCRIPTION
Part 3 of 3 adding the polling pipeline. Follows #44. Ref https://github.com/pyx-industries/rba/issues/8

Split out to be reviewable, this PR adds the pipeline to detect new changes in a polled endpoint, and when changes are detected, spawns a child pipeline, passing the old and new content (ie. this will be list of files which the downstream pipeline of @bla-ce 's can use to pull the new product sheet(s)).

Agent summary:
- Add NewDataDetectionPipeline workflow for endpoint polling with change detection
- Add application layer structure (apps/worker) following ADR contrib module design
- Add Pydantic field validator for Temporal serialization compatibility
- Update data converter to use Pydantic v2 to resolve deprecation warnings
- Include first run, subsequent runs, queries, error handling, and integration tests
- Tests use Temporal's test environment with proper mocking for fast, reliable execution