### PR TITLE
Update ADRs based on conversation with @absoludity

### DIFF
--- a/docs/ADRs/002-doctrine-test-architecture.md
+++ b/docs/ADRs/002-doctrine-test-architecture.md
@@ -112,6 +112,10 @@ Doctrine tests verify these constants contain expected values. This makes the ru
 
 Only doctrine tests use MUST/MAY/MUST NOT language. Other tests are ordinary unit/integration tests.
 
+### Doctrine vs Policy
+
+Not all architectural rules are equal. Some are universal axioms (doctrine) that define what julee concepts ARE. Others are strategic choices (policies) that can be adopted or skipped. See ADR 005 (Doctrine and Policy Separation) for the distinction and how policies are configured.
+
 ## Consequences
 
 ### Positive

--- a/docs/ADRs/005-doctrine-and-policy.md
+++ b/docs/ADRs/005-doctrine-and-policy.md
@@ -10,7 +10,9 @@ Draft
 
 ## Context
 
-ADR 002 established that "tests ARE the doctrine" - test files both express and enforce architectural rules. This has worked well for the julee framework itself, but a gap has emerged: not all rules are equal.
+ADR 002 established that "tests ARE the doctrine" - test files both express and enforce architectural rules. This ADR extends ADR 002 by introducing a distinction between universal axioms (doctrine) and adoptable strategic choices (policy). ADR 002 establishes the mechanism; this ADR refines what qualifies as doctrine versus what should be a separately-adoptable policy.
+
+This has worked well for the julee framework itself, but a gap has emerged: not all rules are equal.
 
 When a developer creates a new solution using julee, they run `julee-admin doctrine verify` against their codebase. Currently, this runs all doctrine tests, including rules that are specific to julee's own structure (Sphinx documentation requirements, MCP framework usage, test organization patterns).
 


### PR DESCRIPTION
## Summary

Updates to ADR 002, 003, and 005 based on review feedback from @absoludity in PRs #71-79.

**ADR 003 (Workflow Orchestration via Handler Services):**
- Rewrote Context section to reflect actual motivation (cross-BC orchestration for reusable modules like Polling) rather than the non-existent `next_action()` pattern
- Added explicit clarification that handlers ARE services (with a specific responsibility)
- Added "unable" to Acknowledgement semantics, completing the radio terminology (wilco/unable/roger)
- Fixed roger semantics: acknowledges receipt with no commitment about action (not "won't comply")
- Made classmethod signatures consistent for Acknowledgement factory methods
- Clarified "use case doesn't know or care about HOW it's handled, only WHETHER"

**ADR 005 (Doctrine and Policy Separation):**
- Added cross-reference explaining relationship to ADR 002

**ADR 002 (Doctrine Test Architecture):**
- Added forward reference to ADR 005 for doctrine vs policy distinction

## Test plan

- [ ] Review updated ADR 003 context section for accuracy
- [ ] Verify Acknowledgement semantics match intended radio terminology
- [ ] Confirm cross-references between ADR 002 and ADR 005 are clear