### PR TITLE
polling: enable scheduling policies to avoid concurrency issue.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "julee"
-version = "0.1.8"
+version = "0.1.9"
 description = "Julee - Clean architecture for accountable and transparent digital supply chains"
 readme = "README.md"
 requires-python = ">=3.11"
-license = {text = "GPL-3.0"}
+license = "GPL-3.0"
 authors = [
     {name = "Pyx Industries", email = "chris@pyx.io"}
 ]
@@ -16,7 +16,7 @@ keywords = ["temporal", "workflow", "document-processing", "ai", "supply-chain"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/julee/__init__.py
+++ b/src/julee/__init__.py
@@ -1,3 +1,3 @@
 """Julee - Clean architecture for accountable and transparent digital supply chains."""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/src/julee/contrib/polling/domain/models/__init__.py
+++ b/src/julee/contrib/polling/domain/models/__init__.py
@@ -6,7 +6,7 @@ This module contains the core domain models for the polling contrib module.
 No re-exports to avoid import chains that pull non-deterministic code
 into Temporal workflows. Import directly from specific modules:
 
-- from julee.contrib.polling.domain.models.polling_config import PollingConfig, PollingProtocol, PollingResult
+- from julee.contrib.polling.domain.models.polling_config import PollingConfig, PollingProtocol, PollingResult, SchedulingPolicy
 """
 
 __all__ = []

--- a/src/julee/contrib/polling/domain/models/polling_config.py
+++ b/src/julee/contrib/polling/domain/models/polling_config.py
@@ -18,6 +18,13 @@ class PollingProtocol(str, Enum):
     HTTP = "http"
 
 
+class SchedulingPolicy(str, Enum):
+    """Scheduling policy for polling operations."""
+
+    ALLOW_OVERLAP = "allow_overlap"
+    SKIP_IF_RUNNING = "skip_if_running"
+
+
 class PollingConfig(BaseModel):
     """Configuration for a polling operation."""
 
@@ -26,6 +33,10 @@ class PollingConfig(BaseModel):
     connection_params: dict[str, Any] = Field(default_factory=dict)
     polling_params: dict[str, Any] = Field(default_factory=dict)
     timeout_seconds: int | None = Field(default=30)
+    scheduling_policy: SchedulingPolicy = Field(
+        default=SchedulingPolicy.ALLOW_OVERLAP,
+        description="Policy for handling overlapping polling operations",
+    )
 
 
 class PollingResult(BaseModel):


### PR DESCRIPTION
When using Julee to demo a polling pipeline, I uploaded multiple files, one after the other, which triggered two polling workflows (since I'd updated the schedule to run every 5s). The problem was that the second one ran before the first was finished, so wasn't able to see the previous completion, which caused an error.

Here we introduce a scheduling policy which is passed through to temporal's own schedule config, so that we can SKIP polling workflows while a previous one is running, avoiding the concurrency issue.

I also had the build fail due to a setuptools deprecation coming into effect on Feb 18, 2026. The `license` is now a string type, not a table type, as per https://packaging.python.org/en/latest/specifications/pyproject-toml/#license (similar for the license classifier).