### PR TITLE
Bump ruff/mypy target to 3.11, fix pyupgrade violations

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -65,4 +65,4 @@ jobs:
         run: uv sync --extra dev
 
       - name: Doctrine tests
-        run: PYTHONPATH=src pytest src/julee/core/doctrine/
+        run: uv run pytest src/julee/core/doctrine/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ exclude_lines = [
 [tool.ruff]
 # Ruff is used for linting only. Formatting is handled by black.
 line-length = 88
-target-version = "py310"
+target-version = "py311"
 exclude = [
     ".git",
     ".venv",
@@ -184,7 +184,7 @@ ignore = [
 known-first-party = ["julee"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
+# Ruff is used for linting only. Formatting is handled by black.
 line-length = 88
 target-version = "py310"
 exclude = [

--- a/src/julee/api/requests.py
+++ b/src/julee/api/requests.py
@@ -7,7 +7,7 @@ to domain model class methods and reuse field descriptions to avoid
 duplication while maintaining single source of truth in the domain layer.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
@@ -90,7 +90,7 @@ class CreateAssemblySpecificationRequest(BaseModel):
         Returns:
             AssemblySpecification: Complete domain object with system fields
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return AssemblySpecification(
             assembly_specification_id=assembly_specification_id,
             name=self.name,
@@ -163,7 +163,7 @@ class CreateKnowledgeServiceQueryRequest(BaseModel):
         Returns:
             KnowledgeServiceQuery: Complete domain object with system fields
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return KnowledgeServiceQuery(
             query_id=query_id,
             name=self.name,

--- a/src/julee/api/responses.py
+++ b/src/julee/api/responses.py
@@ -8,19 +8,19 @@ only response models that are specific to API concerns and not represented
 by existing domain models.
 """
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 
 
-class ServiceStatus(str, Enum):
+class ServiceStatus(StrEnum):
     """Service status enumeration."""
 
     UP = "up"
     DOWN = "down"
 
 
-class SystemStatus(str, Enum):
+class SystemStatus(StrEnum):
     """Overall system status enumeration."""
 
     HEALTHY = "healthy"

--- a/src/julee/api/routers/system.py
+++ b/src/julee/api/routers/system.py
@@ -13,7 +13,7 @@ These routes are mounted at the root level in the main app.
 import asyncio
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from fastapi import APIRouter
 from minio import Minio
@@ -133,6 +133,6 @@ async def health_check() -> HealthCheckResponse:
     # Return response with string timestamp as expected by frontend
     return HealthCheckResponse(
         status=overall_status,
-        timestamp=datetime.now(timezone.utc).isoformat(),
+        timestamp=datetime.now(UTC).isoformat(),
         services=services,
     )

--- a/src/julee/api/tests/routers/test_documents.py
+++ b/src/julee/api/tests/routers/test_documents.py
@@ -6,7 +6,7 @@ focusing on the core functionality of listing documents with pagination.
 """
 
 from collections.abc import Generator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from fastapi import FastAPI
@@ -60,8 +60,8 @@ def sample_documents() -> list[Document]:
             size_bytes=1024,
             content_multihash="QmTest1",
             status=DocumentStatus.CAPTURED,
-            created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-            updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
             additional_metadata={"type": "test"},
             content_bytes="test content",
         ),
@@ -72,8 +72,8 @@ def sample_documents() -> list[Document]:
             size_bytes=2048,
             content_multihash="QmTest2",
             status=DocumentStatus.REGISTERED,
-            created_at=datetime(2024, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
-            updated_at=datetime(2024, 1, 2, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC),
             additional_metadata={"type": "report"},
             content_bytes="pdf content",
         ),

--- a/src/julee/api/tests/routers/test_knowledge_service_configs.py
+++ b/src/julee/api/tests/routers/test_knowledge_service_configs.py
@@ -7,7 +7,7 @@ pagination, and response formats.
 """
 
 from collections.abc import Generator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
@@ -54,24 +54,24 @@ def sample_configs() -> list[KnowledgeServiceConfig]:
             name="Anthropic Claude",
             description="Claude 3 for general text analysis and extraction",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-            updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
         ),
         KnowledgeServiceConfig(
             knowledge_service_id="openai-gpt4",
             name="OpenAI GPT-4",
             description="GPT-4 for comprehensive text understanding",
             service_api=ServiceApi.ANTHROPIC,  # Only enum value available
-            created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-            updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
         ),
         KnowledgeServiceConfig(
             knowledge_service_id="memory-service",
             name="Memory Service",
             description="In-memory service for testing and development",
             service_api=ServiceApi.ANTHROPIC,  # Only enum value available
-            created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-            updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
         ),
     ]
 

--- a/src/julee/contrib/ceap/domain/models/assembly/assembly.py
+++ b/src/julee/contrib/ceap/domain/models/assembly/assembly.py
@@ -13,14 +13,14 @@ and type safety, following the patterns established in the sample project.
 """
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field, field_validator
 
 from julee.core.entities.entity import Entity
 
 
-class AssemblyStatus(str, Enum):
+class AssemblyStatus(StrEnum):
     """Status of an assembly process."""
 
     PENDING = "pending"

--- a/src/julee/contrib/ceap/domain/models/assembly/tests/factories.py
+++ b/src/julee/contrib/ceap/domain/models/assembly/tests/factories.py
@@ -5,7 +5,7 @@ This module provides factory_boy factories for creating test instances of
 Assembly domain objects with sensible defaults.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from factory.base import Factory
 from factory.declarations import LazyFunction
@@ -34,5 +34,5 @@ class AssemblyFactory(Factory):
     assembled_document_id = None
 
     # Timestamps
-    created_at = LazyFunction(lambda: datetime.now(timezone.utc))
-    updated_at = LazyFunction(lambda: datetime.now(timezone.utc))
+    created_at = LazyFunction(lambda: datetime.now(UTC))
+    updated_at = LazyFunction(lambda: datetime.now(UTC))

--- a/src/julee/contrib/ceap/domain/models/assembly/tests/test_assembly.py
+++ b/src/julee/contrib/ceap/domain/models/assembly/tests/test_assembly.py
@@ -20,7 +20,7 @@ Design decisions documented:
 """
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -31,7 +31,7 @@ from .factories import AssemblyFactory
 
 pytestmark = pytest.mark.unit
 
-_NOW = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+_NOW = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
 
 
 class TestAssemblyInstantiation:
@@ -196,8 +196,8 @@ class TestAssemblyDefaults:
 
     def test_assembly_custom_values(self) -> None:
         """Test Assembly with custom non-default values."""
-        custom_created_at = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-        custom_updated_at = datetime(2023, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+        custom_created_at = datetime(2023, 1, 1, 12, 0, 0, tzinfo=UTC)
+        custom_updated_at = datetime(2023, 1, 2, 12, 0, 0, tzinfo=UTC)
 
         custom_assembly = Assembly(
             assembly_id="custom-id",

--- a/src/julee/contrib/ceap/domain/models/assembly_specification/assembly_specification.py
+++ b/src/julee/contrib/ceap/domain/models/assembly_specification/assembly_specification.py
@@ -14,8 +14,8 @@ and type safety, following the patterns established in the sample project.
 """
 
 from collections.abc import Mapping
-from datetime import datetime, timezone
-from enum import Enum
+from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Any
 
 import jsonpointer  # type: ignore
@@ -25,7 +25,7 @@ from pydantic import Field, field_validator
 from julee.core.entities.entity import Entity
 
 
-class AssemblySpecificationStatus(str, Enum):
+class AssemblySpecificationStatus(StrEnum):
     """Status of an assembly specification configuration."""
 
     ACTIVE = "active"
@@ -77,12 +77,8 @@ class AssemblySpecification(Entity):
 
     # AssemblySpecification metadata
     version: str = Field(default="0.1.0", description="Assembly definition version")
-    created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
-    updated_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
+    created_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
     # May later add a detailed description, change log, additional metadata
     # Timestamps
 

--- a/src/julee/contrib/ceap/domain/models/assembly_specification/knowledge_service_query.py
+++ b/src/julee/contrib/ceap/domain/models/assembly_specification/knowledge_service_query.py
@@ -16,7 +16,7 @@ and type safety, following the patterns established in the sample project.
 """
 
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import Field, field_validator
@@ -95,12 +95,8 @@ class KnowledgeServiceQuery(Entity):
         "allowing control over response format and structure.",
     )
 
-    created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
-    updated_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
+    created_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
 
     @field_validator("query_id")
     @classmethod

--- a/src/julee/contrib/ceap/domain/models/assembly_specification/tests/factories.py
+++ b/src/julee/contrib/ceap/domain/models/assembly_specification/tests/factories.py
@@ -5,7 +5,7 @@ This module provides factory_boy factories for creating test instances of
 AssemblySpecification domain objects with sensible defaults.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from factory.base import Factory
@@ -55,8 +55,8 @@ class AssemblyFactory(Factory):
     version = "0.1.0"
 
     # Timestamps
-    created_at = LazyFunction(lambda: datetime.now(timezone.utc))
-    updated_at = LazyFunction(lambda: datetime.now(timezone.utc))
+    created_at = LazyFunction(lambda: datetime.now(UTC))
+    updated_at = LazyFunction(lambda: datetime.now(UTC))
 
 
 class KnowledgeServiceQueryFactory(Factory):
@@ -75,5 +75,5 @@ class KnowledgeServiceQueryFactory(Factory):
     prompt = "Extract test data from the document"
 
     # Timestamps
-    created_at = LazyFunction(lambda: datetime.now(timezone.utc))
-    updated_at = LazyFunction(lambda: datetime.now(timezone.utc))
+    created_at = LazyFunction(lambda: datetime.now(UTC))
+    updated_at = LazyFunction(lambda: datetime.now(UTC))

--- a/src/julee/contrib/ceap/domain/models/document/document.py
+++ b/src/julee/contrib/ceap/domain/models/document/document.py
@@ -9,8 +9,8 @@ and type safety, following the patterns established in the sample project.
 """
 
 from collections.abc import Callable, Mapping
-from datetime import datetime, timezone
-from enum import Enum
+from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field, ValidationInfo, field_validator, model_validator
@@ -41,7 +41,7 @@ def delegate_to_content(*method_names: str) -> Callable[[type], type]:
     return decorator
 
 
-class DocumentStatus(str, Enum):
+class DocumentStatus(StrEnum):
     """Status of a document through the Capture, Extract, Assemble, Publish
     pipeline."""
 
@@ -82,12 +82,8 @@ class Document(Entity):
     assembly_types: tuple[str, ...] = Field(default_factory=tuple)
 
     # Timestamps
-    created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
-    updated_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
+    created_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
 
     # Additional data and content stream
     additional_metadata: Mapping[str, Any] = Field(default_factory=dict)

--- a/src/julee/contrib/ceap/domain/models/document/tests/factories.py
+++ b/src/julee/contrib/ceap/domain/models/document/tests/factories.py
@@ -6,7 +6,7 @@ Document domain objects with sensible defaults.
 """
 
 import io
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from factory.base import Factory
@@ -59,8 +59,8 @@ class DocumentFactory(Factory):
     assembly_types: list[str] = []
 
     # Timestamps
-    created_at = LazyFunction(lambda: datetime.now(timezone.utc))
-    updated_at = LazyFunction(lambda: datetime.now(timezone.utc))
+    created_at = LazyFunction(lambda: datetime.now(UTC))
+    updated_at = LazyFunction(lambda: datetime.now(UTC))
 
     # Additional data
     additional_metadata: dict[str, Any] = {}

--- a/src/julee/contrib/ceap/domain/models/knowledge_service_config/knowledge_service_config.py
+++ b/src/julee/contrib/ceap/domain/models/knowledge_service_config/knowledge_service_config.py
@@ -13,15 +13,15 @@ All domain models use Pydantic BaseModel for validation, serialization,
 and type safety, following the patterns established in the sample project.
 """
 
-from datetime import datetime, timezone
-from enum import Enum
+from datetime import UTC, datetime
+from enum import StrEnum
 
 from pydantic import Field, field_validator
 
 from julee.core.entities.entity import Entity
 
 
-class ServiceApi(str, Enum):
+class ServiceApi(StrEnum):
     """Supported knowledge service APIs."""
 
     ANTHROPIC = "anthropic"
@@ -50,12 +50,8 @@ class KnowledgeServiceConfig(Entity):
     )
 
     # Timestamps
-    created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
-    updated_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
+    created_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
 
     @field_validator("knowledge_service_id")
     @classmethod

--- a/src/julee/contrib/ceap/domain/models/policy/document_policy_validation.py
+++ b/src/julee/contrib/ceap/domain/models/policy/document_policy_validation.py
@@ -17,15 +17,15 @@ All domain models use Pydantic BaseModel for validation, serialization,
 and type safety, following the patterns established in the sample project.
 """
 
-from datetime import datetime, timezone
-from enum import Enum
+from datetime import UTC, datetime
+from enum import StrEnum
 
 from pydantic import Field, field_validator
 
 from julee.core.entities.entity import Entity
 
 
-class DocumentPolicyValidationStatus(str, Enum):
+class DocumentPolicyValidationStatus(StrEnum):
     """Status of a document policy validation process."""
 
     PENDING = "pending"
@@ -96,7 +96,7 @@ class DocumentPolicyValidation(Entity):
 
     # Validation metadata
     started_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(UTC),
         description="When the validation process was initiated",
     )
     completed_at: datetime | None = Field(

--- a/src/julee/contrib/ceap/domain/models/policy/policy.py
+++ b/src/julee/contrib/ceap/domain/models/policy/policy.py
@@ -13,15 +13,15 @@ All domain models use Pydantic BaseModel for validation, serialization,
 and type safety, following the patterns established in the sample project.
 """
 
-from datetime import datetime, timezone
-from enum import Enum
+from datetime import UTC, datetime
+from enum import StrEnum
 
 from pydantic import Field, field_validator
 
 from julee.core.entities.entity import Entity
 
 
-class PolicyStatus(str, Enum):
+class PolicyStatus(StrEnum):
     """Status of a policy configuration."""
 
     ACTIVE = "active"
@@ -71,9 +71,7 @@ class Policy(Entity):
 
     # Policy metadata
     version: str = Field(default="0.1.0", description="Policy version")
-    created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
+    created_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime | None = Field(default=None)
 
     @field_validator("policy_id")

--- a/src/julee/contrib/ceap/domain/models/policy/tests/factories.py
+++ b/src/julee/contrib/ceap/domain/models/policy/tests/factories.py
@@ -5,7 +5,7 @@ This module provides factory_boy factories for creating test instances of
 Policy domain objects with sensible defaults.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from factory.base import Factory
 from factory.declarations import LazyFunction
@@ -40,7 +40,7 @@ class DocumentPolicyValidationFactory(Factory):
     post_transform_validation_scores = None
 
     # Validation metadata
-    started_at = LazyFunction(lambda: datetime.now(timezone.utc))
+    started_at = LazyFunction(lambda: datetime.now(UTC))
     completed_at = None
     error_message = None
 

--- a/src/julee/contrib/ceap/domain/models/policy/tests/test_document_policy_validation.py
+++ b/src/julee/contrib/ceap/domain/models/policy/tests/test_document_policy_validation.py
@@ -13,7 +13,7 @@ Tests focus on:
 - Edge cases and error conditions
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -49,8 +49,8 @@ class TestDocumentPolicyValidationValidation:
 
     def test_full_valid_validation(self) -> None:
         """Test creating a fully populated DocumentPolicyValidation."""
-        started_at = datetime.now(timezone.utc)
-        completed_at = datetime.now(timezone.utc)
+        started_at = datetime.now(UTC)
+        completed_at = datetime.now(UTC)
 
         validation = DocumentPolicyValidation(
             validation_id="val-789",

--- a/src/julee/contrib/ceap/domain/models/policy/tests/test_policy.py
+++ b/src/julee/contrib/ceap/domain/models/policy/tests/test_policy.py
@@ -5,7 +5,7 @@ These tests verify the behavior of Policy domain objects,
 including validation, serialization, and business logic.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -71,8 +71,8 @@ class TestPolicy:
 
     def test_create_policy_with_all_fields(self) -> None:
         """Test creating a policy with all fields specified."""
-        created_at = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-        updated_at = datetime(2024, 1, 2, 12, 0, 0, tzinfo=timezone.utc)
+        created_at = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        updated_at = datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC)
 
         policy = Policy(
             policy_id="policy-003",

--- a/src/julee/contrib/ceap/use_cases/tests/test_extract_assemble_data.py
+++ b/src/julee/contrib/ceap/use_cases/tests/test_extract_assemble_data.py
@@ -8,7 +8,7 @@ following the Clean Architecture principles.
 
 import io
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
@@ -83,8 +83,8 @@ class TestExtractAssembleDataUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         return MemoryKnowledgeService(ks_config)
 
@@ -97,8 +97,8 @@ class TestExtractAssembleDataUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         memory_service = MemoryKnowledgeService(ks_config)
@@ -109,7 +109,7 @@ class TestExtractAssembleDataUseCase:
                     query_text="Extract the title from this document",
                     result_data={"response": "Test Meeting"},
                     execution_time_ms=100,
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                 ),
                 QueryResult(
                     query_id="result-2",
@@ -118,7 +118,7 @@ class TestExtractAssembleDataUseCase:
                         "response": "This was a test meeting about important topics"
                     },
                     execution_time_ms=150,
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                 ),
             ]
         )
@@ -197,8 +197,8 @@ class TestExtractAssembleDataUseCase:
             jsonschema={"type": "object", "properties": {}},
             status=AssemblySpecificationStatus.ACTIVE,
             knowledge_service_queries={},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await assembly_specification_repo.save(assembly_spec)
 
@@ -258,8 +258,8 @@ class TestExtractAssembleDataUseCase:
             content_multihash="test-hash-123",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -283,8 +283,8 @@ class TestExtractAssembleDataUseCase:
                 "/properties/title": "query-1",
                 "/properties/summary": "query-2",
             },
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await assembly_specification_repo.save(assembly_spec)
 
@@ -294,8 +294,8 @@ class TestExtractAssembleDataUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -306,8 +306,8 @@ class TestExtractAssembleDataUseCase:
             knowledge_service_id="ks-123",
             prompt="Extract the title from this document",
             query_metadata={"max_tokens": 100},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         query2 = KnowledgeServiceQuery(
             query_id="query-2",
@@ -315,8 +315,8 @@ class TestExtractAssembleDataUseCase:
             knowledge_service_id="ks-123",
             prompt="Extract a summary from this document",
             query_metadata={"max_tokens": 200},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(query1)
         await knowledge_service_query_repo.save(query2)
@@ -374,8 +374,8 @@ class TestExtractAssembleDataUseCase:
             content_multihash="test-hash-123",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -397,8 +397,8 @@ class TestExtractAssembleDataUseCase:
             knowledge_service_queries={
                 "/properties/title": "query-1",
             },
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await assembly_specification_repo.save(assembly_spec)
 
@@ -408,8 +408,8 @@ class TestExtractAssembleDataUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -420,8 +420,8 @@ class TestExtractAssembleDataUseCase:
             knowledge_service_id="ks-123",
             prompt="Extract the title from this document",
             query_metadata={"max_tokens": 100, "temperature": 0.1},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(query1)
 
@@ -452,7 +452,7 @@ class TestExtractAssembleDataUseCase:
                 query_text=query_text,
                 result_data={"response": "Mock Title"},
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
 
         # Replace the knowledge service execute_query method
@@ -520,8 +520,8 @@ class TestExtractAssembleDataUseCase:
             jsonschema={"type": "object", "properties": {}},
             status=AssemblySpecificationStatus.ACTIVE,
             knowledge_service_queries={},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await assembly_specification_repo.save(assembly_spec)
 
@@ -551,8 +551,8 @@ class TestExtractAssembleDataUseCase:
             content_multihash="test-hash",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -566,8 +566,8 @@ class TestExtractAssembleDataUseCase:
             },
             status=AssemblySpecificationStatus.ACTIVE,
             knowledge_service_queries={"/properties/title": "nonexistent-query"},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await assembly_specification_repo.save(assembly_spec)
 
@@ -599,8 +599,8 @@ class TestExtractAssembleDataUseCase:
             content_multihash="test-hash",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -621,8 +621,8 @@ class TestExtractAssembleDataUseCase:
             jsonschema=schema,
             status=AssemblySpecificationStatus.ACTIVE,
             knowledge_service_queries={"/properties/title": "query-1"},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await assembly_specification_repo.save(assembly_spec)
 
@@ -632,8 +632,8 @@ class TestExtractAssembleDataUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -642,8 +642,8 @@ class TestExtractAssembleDataUseCase:
             name="Extract Title",
             knowledge_service_id="ks-123",
             prompt="Extract the title",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(query)
 
@@ -657,7 +657,7 @@ class TestExtractAssembleDataUseCase:
                     "response": '"Test"'
                 },  # Only returns title, missing "count" field
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 

--- a/src/julee/contrib/ceap/use_cases/tests/test_initialize_system_data.py
+++ b/src/julee/contrib/ceap/use_cases/tests/test_initialize_system_data.py
@@ -9,7 +9,7 @@ These tests use the actual YAML fixture file to validate the real
 integration rather than mocking the file system operations.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -107,8 +107,8 @@ def sample_anthropic_config() -> KnowledgeServiceConfig:
         name="Anthropic Claude",
         description="Claude 3 for general text analysis and extraction",
         service_api=ServiceApi.ANTHROPIC,
-        created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
-        updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        created_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC),
     )
 
 

--- a/src/julee/contrib/ceap/use_cases/tests/test_validate_document.py
+++ b/src/julee/contrib/ceap/use_cases/tests/test_validate_document.py
@@ -7,7 +7,7 @@ following the Clean Architecture principles.
 """
 
 import io
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
@@ -85,8 +85,8 @@ class TestValidateDocumentUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         return MemoryKnowledgeService(ks_config)
 
@@ -109,7 +109,7 @@ class TestValidateDocumentUseCase:
             policy_repo=policy_repo,
             document_policy_validation_repo=document_policy_validation_repo,
             knowledge_service=knowledge_service,
-            now_fn=lambda: datetime.now(timezone.utc),
+            now_fn=lambda: datetime.now(UTC),
         )
 
     def _create_configured_use_case(
@@ -130,7 +130,7 @@ class TestValidateDocumentUseCase:
             policy_repo=policy_repo,
             document_policy_validation_repo=document_policy_validation_repo,
             knowledge_service=memory_service,
-            now_fn=lambda: datetime.now(timezone.utc),
+            now_fn=lambda: datetime.now(UTC),
         )
 
     @pytest.mark.asyncio
@@ -166,8 +166,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-123",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -222,8 +222,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -233,8 +233,8 @@ class TestValidateDocumentUseCase:
             description="Policy with non-existent query",
             status=PolicyStatus.ACTIVE,
             validation_scores=[("nonexistent-query", 80)],
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -266,8 +266,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -278,8 +278,8 @@ class TestValidateDocumentUseCase:
             description="Policy for testing score parsing",
             status=PolicyStatus.ACTIVE,
             validation_scores=[("query-1", 80)],
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -289,8 +289,8 @@ class TestValidateDocumentUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -299,8 +299,8 @@ class TestValidateDocumentUseCase:
             name="Quality Check",
             knowledge_service_id="ks-123",
             prompt="Rate the quality of this document",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(query)
 
@@ -312,7 +312,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate the quality of this document",
                 result_data={"response": "not a number"},  # Invalid score format
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -357,8 +357,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-123",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -372,8 +372,8 @@ class TestValidateDocumentUseCase:
                 ("quality-query", 80),
                 ("clarity-query", 70),
             ],
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -383,8 +383,8 @@ class TestValidateDocumentUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -395,8 +395,8 @@ class TestValidateDocumentUseCase:
             knowledge_service_id="ks-123",
             prompt="Rate the quality of this document on a scale of 0-100",
             query_metadata={"max_tokens": 10},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         clarity_query = KnowledgeServiceQuery(
             query_id="clarity-query",
@@ -404,8 +404,8 @@ class TestValidateDocumentUseCase:
             knowledge_service_id="ks-123",
             prompt="Rate the clarity of this document on a scale of 0-100",
             query_metadata={"max_tokens": 10},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(quality_query)
         await knowledge_service_query_repo.save(clarity_query)
@@ -420,7 +420,7 @@ class TestValidateDocumentUseCase:
                     "scale of 0-100",
                     result_data={"response": "85"},  # Passes requirement of 80
                     execution_time_ms=100,
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                 ),
                 QueryResult(
                     query_id="result-2",
@@ -428,7 +428,7 @@ class TestValidateDocumentUseCase:
                     "scale of 0-100",
                     result_data={"response": "75"},  # Passes requirement of 70
                     execution_time_ms=150,
-                    created_at=datetime.now(timezone.utc),
+                    created_at=datetime.now(UTC),
                 ),
             ]
         )
@@ -489,8 +489,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-456",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -501,8 +501,8 @@ class TestValidateDocumentUseCase:
             description="Requires high quality scores",
             status=PolicyStatus.ACTIVE,
             validation_scores=[("quality-query", 90)],  # High requirement
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -512,8 +512,8 @@ class TestValidateDocumentUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -522,8 +522,8 @@ class TestValidateDocumentUseCase:
             name="Quality Check",
             knowledge_service_id="ks-456",
             prompt="Rate the quality of this document on a scale of 0-100",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(quality_query)
 
@@ -535,7 +535,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate the quality of this document on a " "scale of 0-100",
                 result_data={"response": "60"},  # Fails requirement of 90
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -576,8 +576,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-transform-1",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -589,8 +589,8 @@ class TestValidateDocumentUseCase:
             status=PolicyStatus.ACTIVE,
             validation_scores=[("quality-query", 80)],
             transformation_queries=["improvement-query"],
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -600,8 +600,8 @@ class TestValidateDocumentUseCase:
             name="Transform Knowledge Service",
             description="Service with transformation capability",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -611,16 +611,16 @@ class TestValidateDocumentUseCase:
             name="Quality Check",
             knowledge_service_id="ks-transform-1",
             prompt="Rate the quality of this document on a scale of 0-100",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         improvement_query = KnowledgeServiceQuery(
             query_id="improvement-query",
             name="Document Improvement",
             knowledge_service_id="ks-transform-1",
             prompt="Improve this document to make it higher quality",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(quality_query)
         await knowledge_service_query_repo.save(improvement_query)
@@ -635,7 +635,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate the quality of this document on a scale " "of 0-100",
                 result_data={"response": "60"},  # Initial score fails
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -650,7 +650,7 @@ class TestValidateDocumentUseCase:
                     'clarity."}'
                 },
                 execution_time_ms=200,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -661,7 +661,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate the quality of this document on a scale " "of 0-100",
                 result_data={"response": "85"},  # Post-transform score passes
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -728,8 +728,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-transform-2",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -741,8 +741,8 @@ class TestValidateDocumentUseCase:
             status=PolicyStatus.ACTIVE,
             validation_scores=[("quality-query", 95)],  # Very high requirement
             transformation_queries=["improvement-query"],
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -752,8 +752,8 @@ class TestValidateDocumentUseCase:
             name="Transform Knowledge Service",
             description="Service with transformation capability",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -763,16 +763,16 @@ class TestValidateDocumentUseCase:
             name="Quality Check",
             knowledge_service_id="ks-transform-2",
             prompt="Rate the quality of this document on a scale of 0-100",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         improvement_query = KnowledgeServiceQuery(
             query_id="improvement-query",
             name="Document Improvement",
             knowledge_service_id="ks-transform-2",
             prompt="Try to improve this document",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(quality_query)
         await knowledge_service_query_repo.save(improvement_query)
@@ -787,7 +787,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate the quality of this document on a scale " "of 0-100",
                 result_data={"response": "40"},  # Initial score fails
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -801,7 +801,7 @@ class TestValidateDocumentUseCase:
                     'but still poor quality document."}'
                 },
                 execution_time_ms=200,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -812,7 +812,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate the quality of this document on a scale " "of 0-100",
                 result_data={"response": "70"},  # Still fails requirement of 95
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -865,8 +865,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-no-transform",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -878,8 +878,8 @@ class TestValidateDocumentUseCase:
             status=PolicyStatus.ACTIVE,
             validation_scores=[("quality-query", 80)],
             transformation_queries=["improvement-query"],  # Available but unused
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -889,8 +889,8 @@ class TestValidateDocumentUseCase:
             name="Knowledge Service",
             description="Service description",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -900,16 +900,16 @@ class TestValidateDocumentUseCase:
             name="Quality Check",
             knowledge_service_id="ks-no-transform",
             prompt="Rate the quality of this document on a scale of 0-100",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         improvement_query = KnowledgeServiceQuery(
             query_id="improvement-query",
             name="Document Improvement",
             knowledge_service_id="ks-no-transform",
             prompt="This query should not be called",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(quality_query)
         await knowledge_service_query_repo.save(improvement_query)
@@ -923,7 +923,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate the quality of this document on a scale " "of 0-100",
                 result_data={"response": "90"},  # Passes initial validation
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -973,8 +973,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-invalid-json",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -986,8 +986,8 @@ class TestValidateDocumentUseCase:
             status=PolicyStatus.ACTIVE,
             validation_scores=[("quality-query", 80)],
             transformation_queries=["bad-transform-query"],
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -997,8 +997,8 @@ class TestValidateDocumentUseCase:
             name="Invalid JSON Service",
             description="Service that returns invalid JSON",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -1008,16 +1008,16 @@ class TestValidateDocumentUseCase:
             name="Quality Check",
             knowledge_service_id="ks-invalid-json",
             prompt="Rate the quality of this document on a scale of 0-100",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         bad_transform_query = KnowledgeServiceQuery(
             query_id="bad-transform-query",
             name="Bad Transform Query",
             knowledge_service_id="ks-invalid-json",
             prompt="Transform this document",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(quality_query)
         await knowledge_service_query_repo.save(bad_transform_query)
@@ -1032,7 +1032,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate the quality of this document on a scale " "of 0-100",
                 result_data={"response": "50"},  # Fails, triggers transformation
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -1043,7 +1043,7 @@ class TestValidateDocumentUseCase:
                 query_text="Transform this document",
                 result_data={"response": "This is not valid JSON at all!"},
                 execution_time_ms=200,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 
@@ -1089,8 +1089,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-missing-query",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -1102,8 +1102,8 @@ class TestValidateDocumentUseCase:
             status=PolicyStatus.ACTIVE,
             validation_scores=[("quality-query", 80)],
             transformation_queries=["nonexistent-transform-query"],
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -1113,8 +1113,8 @@ class TestValidateDocumentUseCase:
             name="Missing Query Service",
             description="Service config",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -1124,8 +1124,8 @@ class TestValidateDocumentUseCase:
             name="Quality Check",
             knowledge_service_id="ks-missing-query",
             prompt="Rate the quality of this document on a scale of 0-100",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(quality_query)
         # Note: NOT saving the transformation query
@@ -1160,8 +1160,8 @@ class TestValidateDocumentUseCase:
             content_multihash="test-hash-789",
             status=DocumentStatus.CAPTURED,
             content=ContentStream(io.BytesIO(content_bytes)),
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await document_repo.save(document)
 
@@ -1172,8 +1172,8 @@ class TestValidateDocumentUseCase:
             description="Test policy for out-of-range scores",
             status=PolicyStatus.ACTIVE,
             validation_scores=[("test-query", 80)],
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -1183,8 +1183,8 @@ class TestValidateDocumentUseCase:
             name="Test Knowledge Service",
             description="Test service",
             service_api=ServiceApi.ANTHROPIC,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_config_repo.save(ks_config)
 
@@ -1193,8 +1193,8 @@ class TestValidateDocumentUseCase:
             name="Test Query",
             knowledge_service_id="ks-789",
             prompt="Rate this document",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await knowledge_service_query_repo.save(test_query)
 
@@ -1206,7 +1206,7 @@ class TestValidateDocumentUseCase:
                 query_text="Rate this document",
                 result_data={"response": "150"},  # Out of normal 0-100 range
                 execution_time_ms=100,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
         )
 

--- a/src/julee/contrib/polling/domain/models/polling_config.py
+++ b/src/julee/contrib/polling/domain/models/polling_config.py
@@ -6,8 +6,8 @@ including configuration and result models.
 """
 
 from collections.abc import Mapping
-from datetime import datetime, timezone
-from enum import Enum
+from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field, field_validator
@@ -15,13 +15,13 @@ from pydantic import Field, field_validator
 from julee.core.entities.entity import Entity
 
 
-class PollingProtocol(str, Enum):
+class PollingProtocol(StrEnum):
     """Supported polling protocols."""
 
     HTTP = "http"
 
 
-class SchedulingPolicy(str, Enum):
+class SchedulingPolicy(StrEnum):
     """Scheduling policy for polling operations."""
 
     ALLOW_OVERLAP = "allow_overlap"
@@ -48,7 +48,7 @@ class PollingResult(Entity):
     success: bool
     content: bytes
     metadata: Mapping[str, Any] = Field(default_factory=dict)
-    polled_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    polled_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     content_hash: str | None = None
     error_message: str | None = None
 

--- a/src/julee/contrib/polling/infrastructure/services/polling/http/http_poller_service.py
+++ b/src/julee/contrib/polling/infrastructure/services/polling/http/http_poller_service.py
@@ -7,7 +7,7 @@ REST API endpoints, webhooks, and other HTTP-based data sources.
 
 import hashlib
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
@@ -59,7 +59,7 @@ class HttpPollerService(PollerService):
                 success=success,
                 content=content if success else b"",
                 content_hash=content_hash if success else None,
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 metadata={
                     "status_code": response.status_code,
                     "response_headers": dict(response.headers),
@@ -73,7 +73,7 @@ class HttpPollerService(PollerService):
                 success=False,
                 content=b"",
                 error_message=str(e),
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 metadata={"error_type": type(e).__name__},
             )
 

--- a/src/julee/contrib/polling/tests/unit/apps/worker/test_pipelines.py
+++ b/src/julee/contrib/polling/tests/unit/apps/worker/test_pipelines.py
@@ -11,7 +11,7 @@ workflow orchestration logic and temporal behaviors.
 
 import hashlib
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -56,25 +56,25 @@ def mock_polling_results():
         "first_data": PollingResult(
             success=True,
             content=b"first response data",
-            polled_at=datetime.now(timezone.utc),
+            polled_at=datetime.now(UTC),
             content_hash=hashlib.sha256(b"first response data").hexdigest(),
         ),
         "changed_data": PollingResult(
             success=True,
             content=b"changed response data",
-            polled_at=datetime.now(timezone.utc),
+            polled_at=datetime.now(UTC),
             content_hash=hashlib.sha256(b"changed response data").hexdigest(),
         ),
         "same_data": PollingResult(
             success=True,
             content=b"first response data",  # Same as first_data
-            polled_at=datetime.now(timezone.utc),
+            polled_at=datetime.now(UTC),
             content_hash=hashlib.sha256(b"first response data").hexdigest(),
         ),
         "failed_polling": PollingResult(
             success=False,
             content=b"",
-            polled_at=datetime.now(timezone.utc),
+            polled_at=datetime.now(UTC),
             error_message="Connection timeout",
         ),
     }
@@ -87,7 +87,7 @@ async def mock_poll_endpoint(config: PollingConfig) -> PollingResult:
     return PollingResult(
         success=True,
         content=b"default mock response",
-        polled_at=datetime.now(timezone.utc),
+        polled_at=datetime.now(UTC),
     )
 
 
@@ -107,7 +107,7 @@ class TestNewDataDetectionPipelineFirstRun:
             return PollingResult(
                 success=True,
                 content=content_str.encode(),
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 content_hash=hashlib.sha256(content_str.encode()).hexdigest(),
             )
 
@@ -157,7 +157,7 @@ class TestNewDataDetectionPipelineFirstRun:
             return PollingResult(
                 success=True,
                 content=content_bytes,
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 content_hash=hashlib.sha256(content_bytes).hexdigest(),
             )
 
@@ -217,7 +217,7 @@ class TestNewDataDetectionPipelineSubsequentRuns:
             return PollingResult(
                 success=True,
                 content=content_bytes,
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 content_hash=hashlib.sha256(content_bytes).hexdigest(),
             )
 
@@ -278,7 +278,7 @@ class TestNewDataDetectionPipelineSubsequentRuns:
             return PollingResult(
                 success=True,
                 content=content_bytes,
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 content_hash=hashlib.sha256(content_bytes).hexdigest(),
             )
 
@@ -352,7 +352,7 @@ class TestNewDataDetectionPipelineWorkflowQueries:
             return PollingResult(
                 success=True,
                 content=content_bytes,
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 content_hash=hashlib.sha256(content_bytes).hexdigest(),
             )
 
@@ -449,7 +449,7 @@ class TestNewDataDetectionPipelineErrorHandling:
             return PollingResult(
                 success=True,
                 content=content_bytes,
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 content_hash=hashlib.sha256(content_bytes).hexdigest(),
             )
 
@@ -512,7 +512,7 @@ class TestNewDataDetectionPipelineIntegration:
             result = PollingResult(
                 success=True,
                 content=content_bytes,
-                polled_at=datetime.now(timezone.utc),
+                polled_at=datetime.now(UTC),
                 content_hash=hashlib.sha256(content_bytes).hexdigest(),
             )
             response_index = min(response_index + 1, len(responses) - 1)

--- a/src/julee/core/infrastructure/repositories/file/solution_config.py
+++ b/src/julee/core/infrastructure/repositories/file/solution_config.py
@@ -3,9 +3,8 @@
 Reads [tool.julee] configuration from pyproject.toml.
 """
 
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 from julee.core.entities.policy import SolutionPolicyConfig
 

--- a/src/julee/core/services/clock.py
+++ b/src/julee/core/services/clock.py
@@ -6,7 +6,7 @@ system time or any specific execution framework.
 See ADR 004: Execution-Agnostic Use Cases.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Protocol
 
 
@@ -32,4 +32,4 @@ class SystemClockService:
 
     def now(self) -> datetime:
         """Return the current system time in UTC."""
-        return datetime.now(timezone.utc)
+        return datetime.now(UTC)

--- a/src/julee/docs/sphinx_hcd/domain/models/app.py
+++ b/src/julee/docs/sphinx_hcd/domain/models/app.py
@@ -4,14 +4,14 @@ Represents an application in the HCD documentation system.
 Apps are defined via YAML manifests in apps/*/app.yaml.
 """
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
 from ...utils import normalize_name
 
 
-class AppType(str, Enum):
+class AppType(StrEnum):
     """Application type classification."""
 
     STAFF = "staff"

--- a/src/julee/docs/sphinx_hcd/domain/models/integration.py
+++ b/src/julee/docs/sphinx_hcd/domain/models/integration.py
@@ -4,14 +4,14 @@ Represents an integration module in the HCD documentation system.
 Integrations are defined via YAML manifests in integrations/*/integration.yaml.
 """
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
 from ...utils import normalize_name
 
 
-class Direction(str, Enum):
+class Direction(StrEnum):
     """Integration data flow direction."""
 
     INBOUND = "inbound"

--- a/src/julee/docs/sphinx_hcd/domain/models/journey.py
+++ b/src/julee/docs/sphinx_hcd/domain/models/journey.py
@@ -5,14 +5,14 @@ Journeys are defined via RST directives and track a persona's path
 through the system to achieve a goal.
 """
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
 from ...utils import normalize_name
 
 
-class StepType(str, Enum):
+class StepType(StrEnum):
     """Type of journey step."""
 
     STORY = "story"

--- a/src/julee/repositories/memory/base.py
+++ b/src/julee/repositories/memory/base.py
@@ -19,7 +19,7 @@ Classes using this mixin must provide:
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
@@ -196,7 +196,7 @@ class MemoryRepositoryMixin(Generic[T]):
             New entity instance with updated timestamps (or original if no
             timestamp fields are present)
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         updates: dict[str, Any] = {}
 

--- a/src/julee/repositories/memory/tests/test_document_policy_validation.py
+++ b/src/julee/repositories/memory/tests/test_document_policy_validation.py
@@ -6,7 +6,7 @@ repository implementation, focusing on functionality specific to this
 repository that differs from the inherited mixins.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -45,8 +45,8 @@ def sample_validation() -> DocumentPolicyValidation:
             ("quality-check-query", 95),
             ("completeness-check", 88),
         ],
-        started_at=datetime.now(timezone.utc),
-        completed_at=datetime.now(timezone.utc),
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
         passed=True,
     )
 

--- a/src/julee/repositories/memory/tests/test_policy.py
+++ b/src/julee/repositories/memory/tests/test_policy.py
@@ -6,7 +6,7 @@ repository implementation, following the testing patterns established in the
 project.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -36,8 +36,8 @@ def sample_policy() -> Policy:
         ],
         transformation_queries=["improve-quality", "fix-grammar"],
         version="1.0.0",
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
@@ -54,8 +54,8 @@ def validation_only_policy() -> Policy:
         ],
         transformation_queries=[],  # Empty list - validation only
         version="1.0.0",
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
@@ -435,8 +435,8 @@ class TestMemoryPolicyRepositoryRoundtrip:
             validation_scores=[("round-trip-check", 85)],
             transformation_queries=["round-trip-transform"],
             version="0.1.0",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 

--- a/src/julee/repositories/minio/client.py
+++ b/src/julee/repositories/minio/client.py
@@ -13,7 +13,7 @@ code duplication and ensure consistent error handling and logging.
 
 import io
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import (
     Any,
     BinaryIO,
@@ -493,7 +493,7 @@ class MinioRepositoryMixin:
             New model instance with updated timestamps (or original if no
             timestamp fields are present)
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         updates: dict[str, Any] = {}
 
@@ -517,7 +517,7 @@ class MinioRepositoryMixin:
             Unique ID string in format "{prefix}-{uuid}"
         """
         import uuid
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         generated_id = f"{prefix}-{uuid.uuid4()}"
 
@@ -526,7 +526,7 @@ class MinioRepositoryMixin:
             extra={
                 "generated_id": generated_id,
                 "prefix": prefix,
-                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "generated_at": datetime.now(UTC).isoformat(),
             },
         )
 

--- a/src/julee/repositories/minio/document.py
+++ b/src/julee/repositories/minio/document.py
@@ -15,7 +15,7 @@ import hashlib
 import io
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import multihash  # type: ignore[import-untyped]
 from minio.error import S3Error  # type: ignore[import-untyped]
@@ -104,7 +104,7 @@ class MinioDocumentRepository(DocumentRepository, MinioRepositoryMixin):
                     extra={
                         "document_id": document_id,
                         "content_multihash": content_multihash,
-                        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+                        "retrieved_at": datetime.now(UTC).isoformat(),
                     },
                 )
 

--- a/src/julee/repositories/minio/tests/fake_client.py
+++ b/src/julee/repositories/minio/tests/fake_client.py
@@ -8,7 +8,7 @@ just mocking method calls.
 """
 
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import wraps
 from typing import Any, BinaryIO
 from unittest.mock import Mock
@@ -142,7 +142,7 @@ class FakeMinioClient(MinioClient):
             version_id=None,
             etag="fake-etag",
             http_headers=HTTPHeaderDict(),
-            last_modified=datetime.now(timezone.utc),
+            last_modified=datetime.now(UTC),
             location=f"/{bucket_name}/{object_name}",
         )
 
@@ -167,7 +167,7 @@ class FakeMinioClient(MinioClient):
         return Object(
             bucket_name=bucket_name,
             object_name=object_name,
-            last_modified=datetime.now(timezone.utc),
+            last_modified=datetime.now(UTC),
             etag="fake-etag",
             size=obj_info["size"],
             content_type=obj_info["content_type"],

--- a/src/julee/repositories/minio/tests/test_assembly.py
+++ b/src/julee/repositories/minio/tests/test_assembly.py
@@ -6,7 +6,7 @@ repository implementation, using the fake client to avoid external
 dependencies during testing.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -40,8 +40,8 @@ def sample_assembly() -> Assembly:
         execution_id="test-execution-123",
         status=AssemblyStatus.PENDING,
         assembled_document_id=None,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
@@ -347,8 +347,8 @@ class TestMinioAssemblyRepositoryRoundtrip:
             execution_id="test-execution-success",
             status=AssemblyStatus.PENDING,
             assembled_document_id=None,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await assembly_repo.save(assembly)
 
@@ -394,8 +394,8 @@ class TestMinioAssemblyRepositoryRoundtrip:
             execution_id="test-execution-failure",
             status=AssemblyStatus.PENDING,
             assembled_document_id=None,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await assembly_repo.save(assembly)
 

--- a/src/julee/repositories/minio/tests/test_assembly_specification.py
+++ b/src/julee/repositories/minio/tests/test_assembly_specification.py
@@ -6,7 +6,7 @@ specification repository implementation, using the fake client to avoid
 external dependencies during testing.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -70,8 +70,8 @@ def sample_specification() -> AssemblySpecification:
             "/properties/action_items": "extract-action-items",
         },
         version="1.0.0",
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
@@ -88,8 +88,8 @@ def inactive_specification() -> AssemblySpecification:
         },
         status=AssemblySpecificationStatus.INACTIVE,
         version="1.0.0",
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
@@ -235,8 +235,8 @@ class TestMinioAssemblySpecificationRepositoryComplexScenarios:
             status=AssemblySpecificationStatus.DRAFT,
             knowledge_service_queries={"/properties/test_field": "test-query"},
             version="0.1.0",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await specification_repo.save(specification)
 
@@ -346,8 +346,8 @@ class TestMinioAssemblySpecificationRepositoryComplexScenarios:
             status=AssemblySpecificationStatus.ACTIVE,
             knowledge_service_queries=complex_queries,
             version="2.0.0",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # Save and retrieve
@@ -385,8 +385,8 @@ class TestMinioAssemblySpecificationRepositoryComplexScenarios:
                 "/properties/метаданные": "query-metadata",
             },
             version="1.0.0",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # Save and retrieve

--- a/src/julee/repositories/minio/tests/test_document_policy_validation.py
+++ b/src/julee/repositories/minio/tests/test_document_policy_validation.py
@@ -7,7 +7,7 @@ repository that differs from the inherited mixins. Uses the fake client to
 avoid external dependencies during testing.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -55,8 +55,8 @@ def sample_validation() -> DocumentPolicyValidation:
             ("quality-check-query", 95),
             ("completeness-check", 88),
         ],
-        started_at=datetime.now(timezone.utc),
-        completed_at=datetime.now(timezone.utc),
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
         passed=True,
     )
 
@@ -139,7 +139,7 @@ class TestMinioDocumentPolicyValidationRepositorySpecific:
     ) -> None:
         """Test that save operation preserves existing timestamps."""
         # Create validation with specific timestamps
-        original_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        original_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
         validation = DocumentPolicyValidation(
             validation_id="validation-timestamp-test",
             input_document_id="doc-timestamp",

--- a/src/julee/repositories/minio/tests/test_knowledge_service_config.py
+++ b/src/julee/repositories/minio/tests/test_knowledge_service_config.py
@@ -6,7 +6,7 @@ configuration repository implementation, using the fake client to avoid
 external dependencies during testing.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -45,8 +45,8 @@ def sample_knowledge_service_config() -> KnowledgeServiceConfig:
         name="Test Anthropic Service",
         description="A test knowledge service using Anthropic API",
         service_api=ServiceApi.ANTHROPIC,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 

--- a/src/julee/repositories/minio/tests/test_knowledge_service_query.py
+++ b/src/julee/repositories/minio/tests/test_knowledge_service_query.py
@@ -6,7 +6,7 @@ query repository implementation, using the fake client to avoid external
 dependencies during testing.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -46,15 +46,15 @@ def sample_query() -> KnowledgeServiceQuery:
         prompt="Extract key information from the document",
         assistant_prompt="Format the response as JSON",
         query_metadata={"temperature": 0.2, "max_tokens": 1000},
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
 @pytest.fixture
 def sample_queries() -> list[KnowledgeServiceQuery]:
     """Create multiple sample queries for testing list operations."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return [
         KnowledgeServiceQuery(
             query_id="query-001",
@@ -299,8 +299,8 @@ class TestMinioKnowledgeServiceQueryRepositoryEdgeCases:
             prompt="Main prompt only",
             assistant_prompt=None,
             query_metadata={},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         await query_repo.save(query)
@@ -321,8 +321,8 @@ class TestMinioKnowledgeServiceQueryRepositoryEdgeCases:
             prompt="Test prompt",
             assistant_prompt="Test assistant prompt",
             query_metadata={},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         await query_repo.save(query)
@@ -350,8 +350,8 @@ class TestMinioKnowledgeServiceQueryRepositoryEdgeCases:
             prompt="Test prompt",
             assistant_prompt="Test assistant prompt",
             query_metadata=complex_metadata,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         await query_repo.save(query)
@@ -379,8 +379,8 @@ class TestMinioKnowledgeServiceQueryRepositoryFullWorkflow:
             prompt="Initial prompt",
             assistant_prompt="Initial assistant prompt",
             query_metadata={"version": 1},
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # Save initial query

--- a/src/julee/repositories/minio/tests/test_policy.py
+++ b/src/julee/repositories/minio/tests/test_policy.py
@@ -6,7 +6,7 @@ implementation, using the fake client to avoid external dependencies during
 testing.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -44,8 +44,8 @@ def sample_policy() -> Policy:
         ],
         transformation_queries=["improve-quality", "fix-grammar"],
         version="1.0.0",
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
@@ -62,8 +62,8 @@ def validation_only_policy() -> Policy:
         ],
         transformation_queries=[],  # Empty list - validation only
         version="1.0.0",
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
@@ -319,8 +319,8 @@ class TestMinioPolicyRepositoryComplexScenarios:
             validation_scores=[("lifecycle-check", 80)],
             transformation_queries=["lifecycle-transform"],
             version="0.1.0",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -405,8 +405,8 @@ class TestMinioPolicyRepositoryComplexScenarios:
             ],
             transformation_queries=["transformación", "преобразование"],
             version="1.0.0",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # Save and retrieve
@@ -476,8 +476,8 @@ class TestMinioPolicyRepositoryRoundtrip:
             validation_scores=[("round-trip-check", 85)],
             transformation_queries=["round-trip-transform"],
             version="0.1.0",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
         await policy_repo.save(policy)
 
@@ -515,8 +515,8 @@ class TestMinioPolicyRepositoryRoundtrip:
             ],
             transformation_queries=["transform-1", "transform-2"],
             version="2.0.0",
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         # Save and retrieve

--- a/src/julee/services/knowledge_service/anthropic/knowledge_service.py
+++ b/src/julee/services/knowledge_service/anthropic/knowledge_service.py
@@ -15,7 +15,7 @@ import logging
 import os
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from anthropic import AsyncAnthropic
@@ -141,7 +141,7 @@ class AnthropicKnowledgeService(KnowledgeService):
                     "content_multihash": document.content_multihash,
                     "anthropic_file_id": anthropic_file_id,
                 },
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
 
             logger.info(
@@ -345,7 +345,7 @@ text or markdown formatting."""
                 query_text=query_text,
                 result_data=result_data,
                 execution_time_ms=execution_time_ms,
-                created_at=datetime.now(timezone.utc),
+                created_at=datetime.now(UTC),
             )
 
             logger.info(

--- a/src/julee/services/knowledge_service/anthropic/tests/test_knowledge_service.py
+++ b/src/julee/services/knowledge_service/anthropic/tests/test_knowledge_service.py
@@ -7,7 +7,7 @@ execution functionality.
 """
 
 import io
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -45,8 +45,8 @@ def test_document() -> Document:
         content_multihash="test-hash-123",
         status=DocumentStatus.CAPTURED,
         content=content_stream,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 

--- a/src/julee/services/knowledge_service/knowledge_service.py
+++ b/src/julee/services/knowledge_service/knowledge_service.py
@@ -11,7 +11,7 @@ Concrete implementations of this protocol are provided for different external
 services (Anthropic, OpenAI, etc.) and are created via factory functions.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -42,9 +42,7 @@ class QueryResult(BaseModel):
         default=None,
         description="Time taken to execute the query in milliseconds",
     )
-    created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
+    created_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
 
 
 class FileRegistrationResult(BaseModel):
@@ -58,9 +56,7 @@ class FileRegistrationResult(BaseModel):
         default_factory=dict,
         description="Additional metadata from the registration process",
     )
-    created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
+    created_at: datetime | None = Field(default_factory=lambda: datetime.now(UTC))
 
 
 @runtime_checkable

--- a/src/julee/services/knowledge_service/memory/knowledge_service.py
+++ b/src/julee/services/knowledge_service/memory/knowledge_service.py
@@ -10,7 +10,7 @@ scenarios where external service dependencies should be avoided.
 import json
 import logging
 from collections import deque
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from julee.contrib.ceap.domain.models.document import Document
@@ -183,7 +183,7 @@ class MemoryKnowledgeService(KnowledgeService):
                 "content_type": document.content_type,
                 "size_bytes": document.size_bytes,
             },
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         # Store in memory dictionary keyed by knowledge_service_file_id
@@ -287,7 +287,7 @@ text or markdown formatting."""
                 "knowledge_service_id": config.knowledge_service_id,
             },
             execution_time_ms=result.execution_time_ms,
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
         )
 
         logger.info(

--- a/src/julee/services/knowledge_service/memory/test_knowledge_service.py
+++ b/src/julee/services/knowledge_service/memory/test_knowledge_service.py
@@ -7,7 +7,7 @@ canned query response functionality.
 """
 
 import io
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -41,8 +41,8 @@ def test_document() -> Document:
         content_multihash="test-hash-123",
         status=DocumentStatus.CAPTURED,
         content=content_stream,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 
@@ -173,8 +173,8 @@ class TestMemoryKnowledgeService:
             content_multihash="test-hash-2",
             status=DocumentStatus.CAPTURED,
             content=content_stream,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
         result1 = await memory_service.register_file(
@@ -335,7 +335,7 @@ class TestMemoryKnowledgeService:
         assert original_created_at is not None
         assert result.created_at > original_created_at
         assert (
-            datetime.now(timezone.utc) - result.created_at
+            datetime.now(UTC) - result.created_at
         ).total_seconds() < 5  # Should be very recent
 
     def test_initialization_with_config(

--- a/src/julee/services/knowledge_service/test_factory.py
+++ b/src/julee/services/knowledge_service/test_factory.py
@@ -6,7 +6,7 @@ KnowledgeService implementations based on configuration.
 """
 
 import io
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -44,8 +44,8 @@ def test_document() -> Document:
         content_multihash="test-hash-123",
         status=DocumentStatus.CAPTURED,
         content=content_stream,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
     )
 
 

--- a/src/julee/util/domain.py
+++ b/src/julee/util/domain.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from pydantic import (
     BaseModel,
@@ -14,9 +14,7 @@ class FileMetadata(BaseModel):
     filename: str | None = None
     content_type: str | None = None
     size_bytes: int | None = None
-    uploaded_at: str = Field(
-        default_factory=lambda: datetime.now(timezone.utc).isoformat()
-    )
+    uploaded_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
     metadata: dict[str, str] = Field(default_factory=dict)
 
 


### PR DESCRIPTION
## Summary

- Bump `[tool.ruff] target-version` from `py310` to `py311`
- Bump `[tool.mypy] python_version` from `3.10` to `3.11`
- Fix 279 UP017 violations: `timezone.utc` → `datetime.UTC`
- Fix 13 UP042 violations: `(str, Enum)` → `StrEnum`
- Clean up unused `timezone` and `Enum` imports, re-sort import blocks

## Context

`pyproject.toml` declares `requires-python = ">=3.11"` but both ruff and mypy were targeting 3.10. This is not cosmetic — the doctrine infrastructure imports `tomllib` (stdlib since 3.11), so 3.10 is not actually supported. The stale target suppressed valid pyupgrade suggestions.

All changes are mechanical (auto-fixed by `ruff check --fix` + `black`). No behavioural changes — `datetime.UTC` is just an alias for `timezone.utc`, and `StrEnum` is the stdlib replacement for the `(str, Enum)` pattern.

Stacks on #127.

## Test plan

- [x] `ruff check` passes
- [x] `black --check` passes
- [x] 17 doctrine tests pass
- [x] 335 CEAP + repository tests pass

Fixes #128